### PR TITLE
add a dockerfile to build a deployable container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM registry.access.redhat.com/ubi8/ubi AS builder
+
+RUN yum -y install python3 && pip3 install mkdocs
+
+COPY . /opt
+WORKDIR /opt
+RUN mkdocs build
+
+FROM docker.io/nginx:latest
+COPY --from=builder /opt/site /usr/share/nginx/html


### PR DESCRIPTION
This change is in preparation for deploying the built site to a
kubernetes cluster. It uses a 2 stage build to construct the site and
then copy the static files to a minimal nginx container.