### PR TITLE
update dockerfile to use twisted

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,9 @@ COPY . /opt
 WORKDIR /opt
 RUN mkdocs build
 
-FROM docker.io/nginx:latest
-COPY --from=builder /opt/site /usr/share/nginx/html
+FROM registry.access.redhat.com/ubi8/ubi
+RUN yum -y install python3 && pip3 install twisted
+COPY --from=builder /opt/site /opt/site
+
+WORKDIR /opt/site
+CMD twistd --nodaemon --pidfile /tmp/twistd.pid web --path . --listen tcp:8080


### PR DESCRIPTION
This changes the deployment method for the site to the python twisted
module. The nginx image that was used previously for running the site is
not well prepared to run on OpenShift, this update will make it easier
to utilize the image.