### PR TITLE
add edit_uri mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: OpenShift Infrastructure Provider Onboarding Guide
 repo_url: https://github.com/openshift/infrastructure-provider-onboarding-guide
+edit_uri: edit/main/docs/
 theme:
   name: readthedocs
   highlightjs: true


### PR DESCRIPTION
Resolves https://github.com/openshift/infrastructure-provider-onboarding-guide/issues/8

This will make the "Edit on GitHub" link direct to correct page in the rendered docs.

Reference: https://github.com/mkdocs/mkdocs/blob/master/docs/user-guide/configuration.md#edit_uri